### PR TITLE
chore: add codex support and tenant env

### DIFF
--- a/.codex/README.md
+++ b/.codex/README.md
@@ -1,0 +1,38 @@
+# Codex Context for DannFlow
+
+This folder teaches Codex how to work inside DannFlow while reusing the existing
+Claude Code command library.
+
+## Start Here
+
+Codex should read these files before project work:
+
+1. `AGENTS.md` - cross-agent project rules and guardrails.
+2. `CLAUDE.md` - the richest project context and workflow source.
+3. `.codex/context/dannflow.md` - Codex-specific operating notes.
+4. `.codex/context/claude-compatibility.md` - how to translate Claude-only instructions.
+
+## Commands
+
+Use the Codex commands in `.codex/commands/`:
+
+| Command | Purpose |
+|---|---|
+| `/claude-command <command> [args]` | Load and run the exact prompt from `.claude/commands/`. |
+| `/ask-claude-command <intent>` | Route a plain-English task to the best existing Claude command. |
+
+Examples:
+
+```text
+/claude-command ui src/components/BillingForm.tsx
+/claude-command new-feature billing
+/claude-command sync-upstream --commits 3
+/ask-claude-command make the pricing page responsive and review it
+```
+
+## Source of Truth
+
+Do not duplicate the Claude command library into `.codex`. The canonical command
+prompts remain in `.claude/commands/`; Codex loads them on demand and applies the
+compatibility rules in this folder.
+

--- a/.codex/adapters/command-loader.md
+++ b/.codex/adapters/command-loader.md
@@ -1,0 +1,43 @@
+# Command Loader Contract
+
+This file defines the expected behavior for Codex-compatible Claude command
+loading. It is intentionally written as an agent contract rather than executable
+code so it can be followed by any Codex surface.
+
+## Input
+
+```text
+/claude-command <command-name-or-path> [arguments]
+```
+
+## Resolution
+
+Resolve the command in this order:
+
+1. If input starts with `.claude/commands/`, use it as a relative path.
+2. If input ends with `.md`, use it as a relative path.
+3. Try `.claude/commands/<name>.md`.
+4. Search `.claude/commands/**/<name>.md`.
+
+If zero matches are found, suggest:
+
+```text
+/ask-claude-command <plain-English goal>
+```
+
+If more than one match is found, ask the user to choose the exact path.
+
+## Execution
+
+1. Read the resolved command file fully.
+2. Strip YAML frontmatter only for execution, but retain it as metadata.
+3. Replace `$ARGUMENTS` with the argument string.
+4. Execute the resulting instruction under `AGENTS.md` and Codex environment
+   rules.
+
+## Non-Goals
+
+- Do not duplicate all `.claude/commands` into `.codex/commands`.
+- Do not translate Claude commands permanently unless the user asks.
+- Do not run Claude hooks automatically from Codex.
+

--- a/.codex/commands/ask-claude-command.md
+++ b/.codex/commands/ask-claude-command.md
@@ -1,0 +1,37 @@
+---
+description: Find the best .claude command for a plain-English task and return a ready-to-run /claude-command prompt.
+argument-hint: <plain-English intent>
+---
+
+The user's goal: **$ARGUMENTS**
+
+## Procedure
+
+1. Read `AGENTS.md`, `CLAUDE.md`, and `.codex/context/claude-compatibility.md`.
+2. Scan `.claude/commands/**/*.md`.
+3. For each command, read only the YAML frontmatter and first heading or opening paragraph.
+4. Choose the command or short command chain that best matches the user's goal.
+5. Return a ready-to-run Codex prompt that uses `/claude-command`.
+
+## Output Format
+
+Return only this block:
+
+```text
+/claude-command <command-name> <arguments inferred from the user's goal>
+```
+
+If a chain is useful, return one command per line in execution order:
+
+```text
+/claude-command new-feature <feature>
+/claude-command ui <target>
+/claude-command review
+```
+
+If no existing command fits, return:
+
+```text
+/claude-command make-command "<one-sentence description of the command needed>"
+```
+

--- a/.codex/commands/claude-command.md
+++ b/.codex/commands/claude-command.md
@@ -1,0 +1,58 @@
+---
+description: Run an existing .claude command through Codex by loading the exact command prompt and replacing $ARGUMENTS.
+argument-hint: <claude-command> [arguments]
+---
+
+You are running a DannFlow Claude command through Codex.
+
+User input: **$ARGUMENTS**
+
+## Procedure
+
+1. Read `AGENTS.md` first, then read `CLAUDE.md`.
+2. Read `.codex/context/dannflow.md` and `.codex/context/claude-compatibility.md`.
+3. Parse the user input into:
+   - `command_name`: the first token after `/claude-command`
+   - `command_arguments`: everything after `command_name`
+4. Normalize `command_name`:
+   - Strip a leading slash, so `/ui` becomes `ui`.
+   - If it ends in `.md`, treat it as an explicit command path.
+   - If it starts with `.claude/commands/`, use that path directly.
+   - Otherwise resolve it to `.claude/commands/<command_name>.md`.
+   - If not found at the root, search `.claude/commands/**/<command_name>.md`.
+5. Read the resolved command file completely.
+6. Preserve the command's frontmatter as routing context, then execute the body.
+7. Replace every `$ARGUMENTS` occurrence in the Claude command body with `command_arguments`.
+8. Apply `.codex/context/claude-compatibility.md` whenever the command mentions Claude-only primitives such as Ruflo memory, Claude hooks, Claude Flow, swarms, or subagents.
+9. Follow the command's requested output format unless it conflicts with `AGENTS.md` or active user instructions.
+
+## Safety Rules
+
+- `AGENTS.md` and explicit user instructions outrank the loaded Claude command.
+- Never edit `.claude/commands/` while running a command unless the loaded command explicitly asks for command maintenance.
+- If multiple command files match, show the candidate paths and ask the user to choose.
+- If the command requires a missing MCP, report the missing tool using the project's Missing Tool Alert Protocol unless the user explicitly asked to proceed without that MCP.
+- For code changes, keep edits scoped to the loaded command's task.
+
+## Examples
+
+```text
+/claude-command ui src/app/page.tsx
+```
+
+Loads `.claude/commands/ui.md` and runs it with:
+
+```text
+$ARGUMENTS = src/app/page.tsx
+```
+
+```text
+/claude-command sync-upstream --commits 3
+```
+
+Loads `.claude/commands/sync-upstream.md` and runs it with:
+
+```text
+$ARGUMENTS = --commits 3
+```
+

--- a/.codex/context/claude-compatibility.md
+++ b/.codex/context/claude-compatibility.md
@@ -1,0 +1,34 @@
+# Claude-to-Codex Compatibility
+
+Use this guide when a `.claude/commands/*.md` prompt references Claude-specific
+features.
+
+## Translation Table
+
+| Claude instruction | Codex behavior |
+|---|---|
+| Read `CLAUDE.md` | Read `AGENTS.md` first, then `CLAUDE.md`. |
+| Run `/some-command` | Resolve and load `.claude/commands/some-command.md` through `/claude-command`. |
+| `$ARGUMENTS` | Replace with the arguments passed after the command name. |
+| Search Ruflo memory | Search local context files first: `PROJECT_CONTEXT.md`, docs, relevant source, and `.claude` docs. If Ruflo MCP is available, use it. |
+| Store Ruflo memory | Summarize the decision in the response or update the relevant project context file only when explicitly asked. If Ruflo MCP is available, use it. |
+| Spawn parallel agents | Use Codex subagents or parallel tool calls when available. Otherwise split the task internally and execute sequentially. |
+| Claude hooks | Treat as advisory. Codex does not automatically run Claude Code hooks. |
+| Claude Flow, swarms, hive mind | Use only if matching MCP/tools are connected. Otherwise preserve the intent with normal Codex planning and execution. |
+| Use Opus | Use the active Codex model. Mention model-specific requirements only if they affect risk or scope. |
+
+## Precedence
+
+1. Current user instructions.
+2. `AGENTS.md`.
+3. Safety and filesystem rules from the active Codex environment.
+4. `CLAUDE.md`.
+5. The loaded `.claude/commands/*.md` prompt.
+6. This compatibility guide.
+
+## Missing Tools
+
+When a loaded command requires an MCP that is not available, follow the Missing
+Tool Alert Protocol from `AGENTS.md`, unless the user explicitly says to proceed
+without discussing MCPs.
+

--- a/.codex/context/dannflow.md
+++ b/.codex/context/dannflow.md
@@ -1,0 +1,48 @@
+# Business Template Notes for Codex
+
+Business Template is a multi-tenant client website platform built on DannFlow.
+It uses Next.js 15+, React 19, Supabase, Tailwind v4, and Shadcn/UI.
+
+Each client is isolated by `organization_id`, and shared developer namespace
+tables can also require `app_id`. Treat these as security boundaries.
+
+## Operating Order
+
+1. Read `AGENTS.md` before taking action.
+2. Read `CLAUDE.md` for richer project context.
+3. For feature work, check `PROJECT_CONTEXT.md` if present.
+4. For new features, check `src/prompts/features/` before scaffolding.
+5. Keep business logic and Supabase queries in `src/services/`.
+6. Use generated types from `src/types/supabase.ts`; never use `any`.
+
+## Database Discipline
+
+Assume RLS is active on every table. Service queries must include explicit
+`organization_id`, `app_id`, user, or ownership filters unless the endpoint is
+intentionally public.
+
+Before schema-sensitive work:
+
+```bash
+npm run checkpoint
+npm run update-types
+```
+
+Use Supabase MCP for live schema reads and migrations when available.
+
+## UI Discipline
+
+Use Tailwind and Shadcn semantic tokens only:
+
+- Backgrounds: `bg-background`, `bg-card`, `bg-muted`
+- Text: `text-foreground`, `text-muted-foreground`, `text-primary`
+- Borders: `border`, `border-border`, `border-input`
+- Brand: `bg-primary`, `text-primary-foreground`
+
+Avoid raw `button` elements for app UI. Use Shadcn `Button`.
+
+## Codex Command Bridge
+
+The `.claude/commands/` files remain the command source of truth. Codex should
+load those prompts through `.codex/commands/claude-command.md` instead of copying
+or rewriting them.

--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,8 @@
 # ── App Identity ───────────────────────────────────────────────────────────────
 NEXT_PUBLIC_APP_ID=chris-auto-shine
-NEXT_PUBLIC_SITE_URL=https://chrisautoshine.vercel.app
-NEXT_PUBLIC_SITE_NAME=Chris Auto Shine
+NEXT_PUBLIC_ORG_ID=506a6266-a437-4751-9853-086a5272c861
+NEXT_PUBLIC_SITE_URL=https://www.chrisautoshinedetailing.com.au
+NEXT_PUBLIC_SITE_NAME=Chris Auto Shine Detailing
 
 # ── Supabase ────────────────────────────────────────────────────────────────────
 # This project uses the shared Dannflow Supabase project.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,111 @@
+<!-- BEGIN:nextjs-agent-rules -->
+# Project Rules & AI Steering (AGENTS.md)
+
+> **Start here**: Always read this file first before taking any action on this project.
+
+You are an expert developer working on **Dann's Vibe-Coding Starter**. This project uses **Next.js 15+ (App Router)** and follows a strict **"Vibe Coding"** architecture built for clarity, speed, and maintainability.
+
+## Diagnostic Protocol
+**Unified Dependency Check**: Before starting any specialized tasks, verify that the required MCP (Model Context Protocol) tools are enabled and connected.
+
+- **Supabase MCP**: Essential for database schema reading, SQL execution, and types validation.
+- **GitHub MCP**: Essential for version control tasks, including comparing branches, resolving merge conflicts, and checking commit history before suggesting broad refactors.
+- **Terminal MCP**: Essential for running local backup commands and interacting with the local system environment.
+
+**Missing Tool Alert Protocol:** 
+If any required MCP tool is missing for the current task, stop immediately and provide the exact instruction block below:
+
+⚠️ [Tool Name] MCP Not Detected: I need this to [Specific Task].
+To fix: 
+> 1. Open your AI IDE's MCP Store (Settings → MCP Store).
+> 2. Install "[Tool Name]" and follow the setup.
+> 3. Use your credentials from .env.local.
+
+## Architectural Guardrails
+1.  **Separation of Concerns**: UI components must NOT contain database logic or direct API calls.
+2.  **Logic Layer**: All business logic and Supabase queries MUST live strictly within `src/services/`.
+3.  **Context First**: ALWAYS look for a feature blueprint in `src/prompts/features/` before starting a new task.
+4.  **Type Safety**: Use the generated TypeScript types from `src/types/` for all data structures. Never use `any`.
+
+## 🛠 Tech Stack Conventions
+-   **React**: Use Functional Components and Hooks. Favor Server Components for data fetching.
+-   **CSS**: Use Tailwind CSS for all styling.
+-   **Components**: Use Shadcn/UI for UI primitives.
+-   **Async**: Use `async/await` for all asynchronous operations.
+
+## Vibe Workflow
+-   If you encounter a bug, fix it in the **Service** layer first.
+-   If you need a new data structure, define or request generation of its types in `src/types/` first.
+-   **GitHub MCP Mastery**: Use the GitHub MCP whenever the user reports a regression or a merge conflict. Compare current files with historical commits before asking for manual diffs.
+-   **Codex Compatibility**: If the user invokes `/claude-command <command> [args]`, read `.codex/commands/claude-command.md`, resolve the matching `.claude/commands/*.md` file, replace `$ARGUMENTS` with the provided args, and execute the loaded prompt under these AGENTS.md rules.
+-   **Command Source of Truth**: Keep `.claude/commands/` as the canonical command library. Do not duplicate every Claude command into `.codex/`; `.codex/` is the adapter/context layer for Codex.
+-   **Backup & Snapshot**: If the user runs `npm run checkpoint` and provides the generated prompt, you must:
+    1. Verify Supabase MCP connection.
+    2. Read the live schema (Tables, Enums, RLS, Triggers) for the specified project ID.
+    3. Generate the full DDL and save it to the specified timestamped SQL file in `supabase/backups/`.
+-   **Project Provisioning**: If requested to create a new project and apply a schema:
+    1. List organizations to help the user choose one.
+    2. Ask for the Project Name and Organization ID.
+    3. Check costs using `get_cost` and `confirm_cost` before `create_project`.
+    4. After initialization, read the latest backup from `supabase/backups/` and apply it using `apply_migration`.
+-   **Project Initialization & Migration**: If a user provides a Project ID for a new project:
+    1. Locate the latest `.sql` backup in `supabase/backups/`.
+    2. Read and apply the schema using the Supabase MCP.
+    3. **MANDATORY Verification**: After execution, list tables and functions in the `public` schema.
+    4. Confirm existence of core architecture (`profiles` table, `handle_new_user` function).
+    5. Do not report success until verification is complete.
+-   **Be concise and proactive**. If you see an obvious optimization that fits the application's clean aesthetic, suggest it.
+
+## 🔒 RLS Security Constraint (Non-Negotiable)
+Always check `src/types/supabase.ts` and **assume RLS is active on every table**. Every `select` or `update` in a service must include an `.eq('id', userId)` filter to pass security policies unless explicitly building a public endpoint. Skipping this is a security vulnerability.
+
+## Code Architecture Rules
+1.  **Maintain Structure**: DO NOT arbitrarily change existing UI structure, folder hierarchy, or core logic unless explicitly asked.
+2.  **MODULARITY**: Extract repeatable logic into reusable components or custom hooks; avoid spaghetti code.
+3.  **DIRECTORY**: Place new components in the existing `/components/` folder and logic in `/lib/` or `/hooks/`.
+4.  **CLEANLINESS**: Adhere to DRY (Don't Repeat Yourself) and SOLID design principles.
+5.  **OUTPUT**: If any code changes are made, provide a concise, professional Git commit message (e.g., 'feat: add user login validation') at the end of your response for easy copy-pasting.
+6.  **SERVER VS. CLIENT**: Default to Server Components. Only use `'use client'` when interactivity, client state, or specific lifecycle effects are strictly required.
+7.  **STRICT SEMANTIC COMPLIANCE**: Use ONLY Shadcn/Tailwind semantic tokens (e.g., bg-background, bg-card, text-foreground). Stating hex codes, rgba, or hardcoded neutral/white/blur colors is a CRITICAL FAILURE.
+
+
+## 🎨 UI Quality Standards (Non-Negotiable)
+- **Mobile-First**: Every component must be fully responsive. Start at 375px. No horizontal scroll.
+- **Touch Targets**: All interactive elements (buttons, inputs, links) must be at minimum 48px tall.
+- **Visual Hierarchy**: Use font-size, weight, and spacing intentionally. Headings must feel like headings.
+- **Form UX**: Labels go ABOVE inputs, never as placeholder-only. Inputs must have visible focus rings using `ring-ring`.
+- **Spacing Rhythm**: Use consistent spacing scale (p-4, p-6, gap-4, gap-6). Never cram elements together.
+- **Feedback States**: Every button must have a loading state. Every input must have an error state. Use `text-destructive` for errors.
+- **Empty States**: Never leave a blank screen. Use a centered icon + message for empty or loading states.
+- **Semantic Tokens in Practice**: 
+  - Backgrounds: `bg-background`, `bg-card`, `bg-muted`
+  - Text: `text-foreground`, `text-muted-foreground`, `text-primary`
+  - Borders: `border`, `border-border`, `border-input`
+  - Buttons: always use Shadcn `<Button variant="default">` or `variant="outline"` — never raw `<button>`
+- **Card Pattern**: Wrap all form pages in `<Card>` with `<CardHeader>`, `<CardContent>`, `<CardFooter>` from Shadcn.
+- **Multi-step Forms**: Use a visible step indicator (e.g., "Step 2 of 3") with a progress bar using `bg-primary`.
+
+
+## 🗄️ Supabase Workflow for AI Agents
+1. **Live Schema Awareness**: Use the **Supabase MCP Server** to query the live database state (tables, types, RLS policies). Do not assume schema structure without checking.
+2. **Schema Changes via MCP**: Execute SQL directly using the MCP when prompted to alter tables or policies. Do not ask the user for manual SQL entry.
+3. **Sync Types**: After any schema change, instruct the user to run `npm run update-types` to refresh `src/types/supabase.ts` via the Supabase CLI. Rely ONLY on these generated definitions.
+4. **RLS Constraint**: Always assume Row Level Security (RLS) is active. By default, write queries that respect RLS constraints.
+
+## Project Overview
+A high-performance Next.js starter optimized for AI-native development (Vibe Coding), featuring automated type-safety and live database orchestration.
+
+## Codex Command Bridge
+DannFlow supports Codex through the `.codex/` folder:
+
+- `.codex/commands/claude-command.md` defines `/claude-command <claude-command> [arguments]`.
+- `.codex/commands/ask-claude-command.md` routes a plain-English task to the best existing Claude command.
+- `.codex/context/claude-compatibility.md` translates Claude-only concepts such as Ruflo memory, Claude hooks, Claude Flow, swarms, and model names into Codex behavior.
+
+When running a Claude command from Codex:
+1. Read `AGENTS.md` first, then `CLAUDE.md`.
+2. Resolve the command from `.claude/commands/`.
+3. Replace `$ARGUMENTS` with the user-provided argument string.
+4. Follow the loaded command unless it conflicts with AGENTS.md, active user instructions, or Codex environment safety rules.
+5. If the command requires unavailable MCP tooling, use the Missing Tool Alert Protocol unless the user explicitly says to proceed without discussing MCPs.
+<!-- END:nextjs-agent-rules -->


### PR DESCRIPTION
## Summary
- add Codex command adapter/context files to Chris Auto Shine v2
- add AGENTS.md so Codex follows the project rules in this repo
- update `.env.example` with the Chris tenant app/org/site identity values

## Validation
- `git diff --check`

## Local note
- `.env.local` was updated locally with `NEXT_PUBLIC_ORG_ID`, but it remains ignored and is not part of this PR.
