### PR TITLE
chore: sync env example variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,12 @@ NEXT_PUBLIC_SITE_NAME=Chris Auto Shine Detailing
 # See docs/SUPABASE_PLAN.md for setup instructions.
 NEXT_PUBLIC_SUPABASE_URL=
 NEXT_PUBLIC_SUPABASE_ANON_KEY=
+SUPABASE_SERVICE_ROLE_KEY=
+
+# ── Rate Limiting (Optional — Upstash Redis) ───────────────────────────────────
+# Leave blank to skip rate limiting when the app does not use it.
+UPSTASH_REDIS_REST_URL=
+UPSTASH_REDIS_REST_TOKEN=
 
 # ── EmailJS (Contact Form) ──────────────────────────────────────────────────────
 NEXT_PUBLIC_EMAILJS_SERVICE_ID=


### PR DESCRIPTION
## Summary
- align `.env.example` with the variable list used by local and Vercel environments
- add server-only service-role and optional Upstash placeholders without committing secret values

## Validation
- compared `.env.example` and `.env.local` variable names only
